### PR TITLE
Update seccomp patch, based on staging patch

### DIFF
--- a/patches/wine/seccomp-external-filter.patch
+++ b/patches/wine/seccomp-external-filter.patch
@@ -1,30 +1,65 @@
 diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
-index dabe436bfe7..3dc45b92bf7 100644
+index dabe436bfe7..2954d02975f 100644
 --- a/dlls/ntdll/unix/signal_x86_64.c
 +++ b/dlls/ntdll/unix/signal_x86_64.c
-@@ -2177,8 +2177,12 @@ static void install_bpf(struct sigaction *sig_act)
+@@ -2159,7 +2159,7 @@ static void install_bpf(struct sigaction *sig_act)
+         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+     };
+     struct sock_fprog prog;
+-    int ret;
++    NTSTATUS status;
+ 
+     memset(&prog, 0, sizeof(prog));
+     prog.len = ARRAY_SIZE(filter);
+@@ -2177,32 +2177,31 @@ static void install_bpf(struct sigaction *sig_act)
          }
      }
  
 -    if (!(ret = prctl(PR_GET_SECCOMP, 0, NULL, 0, 0)))
-+    ret = prctl(PR_GET_SECCOMP, 0, NULL, 0, 0);
-+    if (ret >= 0)
-     {
-+        if (ret == 2)
-+            TRACE("Seccomp filters are installed, but applying anyway.\n");
-+
-         if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0))
-         {
-             perror("prctl(PR_SET_NO_NEW_PRIVS, ...)");
-@@ -2196,10 +2200,7 @@ static void install_bpf(struct sigaction *sig_act)
+-    {
+-        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0))
+-        {
+-            perror("prctl(PR_SET_NO_NEW_PRIVS, ...)");
+-            exit(1);
+-        }
++    sigaction(SIGSYS, sig_act, NULL);
+ 
+-        if (sc_seccomp(SECCOMP_SET_MODE_FILTER, flags, &prog))
++    if ((status = syscall(0xffff)) == STATUS_INVALID_PARAMETER)
++    {
++        TRACE("Seccomp filters already installed.\n");
++        return;
++    }
++    if (status != -ENOSYS && (status != -1 || errno != ENOSYS))
++    {
++        ERR("Unexpected status %#x, errno %d.\n", status, errno);
++        return;
++    }
+ 
+-        {
+-            perror("prctl(PR_SET_SECCOMP, ...)");
+-            exit(1);
+-        }
+ 
+-        check_bpf_jit_enable();
++    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0))
++    {
++        perror("prctl(PR_SET_NO_NEW_PRIVS, ...)");
++        exit(1);
      }
-     else
+-    else
++    if (sc_seccomp(SECCOMP_SET_MODE_FILTER, flags, &prog))
      {
 -        if (ret == 2)
 -            TRACE("Seccomp filters already installed.\n");
 -        else
 -            ERR("Seccomp filters cannot be installed, ret %d, error %s.\n", ret, strerror(errno));
-+        ERR("Seccomp filters cannot be installed, ret %d, error %s.\n", ret, strerror(errno));
++        perror("prctl(PR_SET_SECCOMP, ...)");
++        exit(1);
      }
- 
-     sigaction(SIGSYS, sig_act, NULL);
+-
+-    sigaction(SIGSYS, sig_act, NULL);
++    check_bpf_jit_enable();
+ #else
+     WARN("Built without seccomp.\n");
+ #endif


### PR DESCRIPTION
Adopted patch from https://github.com/ValveSoftware/wine/issues/99#issuecomment-721260612

<details>
<summary>Original Wine code from Proton (as before #5)</summary>

```c
    int ret;
```
```c
    if (!(ret = prctl(PR_GET_SECCOMP, 0, NULL, 0, 0)))
    {
        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0))
        {
            perror("prctl(PR_SET_NO_NEW_PRIVS, ...)");
            exit(1);
        }

        if (sc_seccomp(SECCOMP_SET_MODE_FILTER, flags, &prog))

        {
            perror("prctl(PR_SET_SECCOMP, ...)");
            exit(1);
        }

        check_bpf_jit_enable();
    }
    else
    {
        if (ret == 2)
            TRACE("Seccomp filters already installed.\n");
        else
            ERR("Seccomp filters cannot be installed, ret %d, error %s.\n", ret, strerror(errno));
    }

    sigaction(SIGSYS, sig_act, NULL);
```
</details>

<details>
<summary>Patched code (after this PR)</summary>

```c
    NTSTATUS status;
```
```c
    sigaction(SIGSYS, sig_act, NULL);

    if ((status = syscall(0xffff)) == STATUS_INVALID_PARAMETER)
    {
        TRACE("Seccomp filters already installed.\n");
        return;
    }
    if (status != -ENOSYS && (status != -1 || errno != ENOSYS))
    {
        ERR("Unexpected status %#x, errno %d.\n", status, errno);
        return;
    }


    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0))
    {
        perror("prctl(PR_SET_NO_NEW_PRIVS, ...)");
        exit(1);
    }
    if (sc_seccomp(SECCOMP_SET_MODE_FILTER, flags, &prog))
    {
        perror("prctl(PR_SET_SECCOMP, ...)");
        exit(1);
    }
    check_bpf_jit_enable();
```
</details>

Since I'm not familiar with C and not sure if got everything right, a review from someone more knowledgeable would be very useful.