### PR TITLE
Make more room for bundled libraries

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -24,6 +24,7 @@ build-options:
                      :/app/share/pkgconfig\
                      :/usr/lib/x86_64-linux-gnu/pkgconfig\
                      :/usr/share/pkgconfig"
+    LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton/lib
   cflags: &optflags -O2 -pipe -march=nocona -mtune=core-avx2 -mfpmath=sse -fwrapv -fno-strict-aliasing
   cflags-override: true
   cxxflags: *optflags
@@ -41,6 +42,7 @@ x-compat-i386-opts: &compat_i386_opts
                      :/app/share/pkgconfig\
                      :/usr/lib/i386-linux-gnu/pkgconfig\
                      :/usr/share/pkgconfig"
+    LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton/lib32
   libdir: /app/share/steam/compatibilitytools.d/Proton/lib32
 
 x-proton-source: &proton_source
@@ -132,8 +134,6 @@ modules:
   - name: wine
     subdir: wine
     build-options:
-      env:
-        LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton/lib
       arch:
         x86_64:
           config-opts:
@@ -168,8 +168,6 @@ modules:
     only-arches:
       - x86_64
     build-options:
-      env:
-        LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton/lib32
       arch:
         x86_64: *compat_i386_opts
       config-opts:

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -19,19 +19,28 @@ build-options:
   env:
     C_INCLUDE_PATH: /app/share/steam/compatibilitytools.d/Proton/include:/app/include
     CPLUS_INCLUDE_PATH: /app/share/steam/compatibilitytools.d/Proton/include:/app/include
+    PKG_CONFIG_PATH: "/app/share/steam/compatibilitytools.d/Proton/lib/pkgconfig\
+                     :/app/lib/pkgconfig\
+                     :/app/share/pkgconfig\
+                     :/usr/lib/x86_64-linux-gnu/pkgconfig\
+                     :/usr/share/pkgconfig"
   cflags: &optflags -O2 -pipe -march=nocona -mtune=core-avx2 -mfpmath=sse -fwrapv -fno-strict-aliasing
   cflags-override: true
   cxxflags: *optflags
   cxxflags-override: true
 
 x-compat-i386-opts: &compat_i386_opts
-  prepend-pkg-config-path: /app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig
   ldflags: -L/app/share/steam/compatibilitytools.d/Proton/lib32 -L/app/lib32
   prepend-path: /app/share/steam/compatibilitytools.d/Proton/bin32
   append-path: /usr/lib/sdk/toolchain-i386/bin
   env:
     CC: ccache i686-unknown-linux-gnu-gcc
     CXX: ccache i686-unknown-linux-gnu-g++
+    PKG_CONFIG_PATH: "/app/share/steam/compatibilitytools.d/Proton/lib32/pkgconfig\
+                     :/app/lib32/pkgconfig\
+                     :/app/share/pkgconfig\
+                     :/usr/lib/i386-linux-gnu/pkgconfig\
+                     :/usr/share/pkgconfig"
   libdir: /app/share/steam/compatibilitytools.d/Proton/lib32
 
 x-proton-source: &proton_source
@@ -123,7 +132,6 @@ modules:
   - name: wine
     subdir: wine
     build-options:
-      prepend-pkg-config-path: /app/share/steam/compatibilitytools.d/Proton/lib/pkgconfig
       env:
         LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton/lib
       arch:
@@ -160,7 +168,6 @@ modules:
     only-arches:
       - x86_64
     build-options:
-      prepend-pkg-config-path: /app/share/steam/compatibilitytools.d/Proton/lib32/pkgconfig
       env:
         LD_RUN_PATH: /app/share/steam/compatibilitytools.d/Proton/lib32
       arch:


### PR DESCRIPTION
This makes easier to bundle more libs in the extension (if we decide to) making sure that bundled dependencies from the extension take priority over app/runtime ones.