### PR TITLE
Indicate version in metainfo

### DIFF
--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.metainfo.xml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.metainfo.xml
@@ -13,4 +13,7 @@
   <url type="bugtracker">https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton/issues</url>
   <project_license>BSD-3-Clause and LGPL-2.1 and zlib-acknowledgement and Zlib and OFL-1.1 and MIT and MPL-2.0 and LicenseRef-proprietary</project_license>
   <metadata_license>CC0-1.0</metadata_license>
+  <releases>
+    <release version="@VERSION@" date="@DATE@"/>
+  </releases>
 </component>

--- a/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
+++ b/com.valvesoftware.Steam.CompatibilityTool.Proton.yml
@@ -529,13 +529,19 @@ modules:
       - install -Dm644 toolmanifest_noruntime.vdf ${FLATPAK_DEST}/toolmanifest.vdf
       - install -Dm644 dist.LICENSE ${FLATPAK_DEST}/LICENSE
       - |
+        set -e -o pipefail
         PROTON_VERSION=$(git describe --tags | sed 's/^proton-//')
+        PROTON_DATE=$(git show -s --format=%cs)
         TIMESTAMP=$(date +%s)
         echo ${TIMESTAMP} proton_flatpak-${PROTON_VERSION} > ${FLATPAK_DEST}/version
         sed \
           -e "s/@VERSION@/${PROTON_VERSION}/g" \
           -e "s/@BUILD@/${TIMESTAMP}/g" \
           -i ${FLATPAK_DEST}/compatibilitytool.vdf
+        sed \
+          -e "s/@VERSION@/${PROTON_VERSION}/g" \
+          -e "s/@DATE@/${PROTON_DATE}/g" \
+          -i ${FLATPAK_ID}.metainfo.xml
       - |
         cd ${FLATPAK_DEST}
         mkdir dist


### PR DESCRIPTION
AFAICT the frontends like GNOME Software and KDE Discover expose extension version from the `release` tag only on update, but I think it's better than no version indication at all.
@Lctrs @nanonyme do you think it's worthwhile to also indicate proton version in `name` or `summary`?